### PR TITLE
Merge extra attributes in alert component with escape disabled

### DIFF
--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -11,7 +11,7 @@
     $actions = $getActions();
 @endphp
 
-<div {{ $attributes->class([
+<div {{ $attributes->merge($getExtraAttributes(), escape: false)->class([
     'fi-super-alert'
 ])->color(BadgeComponent::class, $color) }}>
     @if ($icon)


### PR DESCRIPTION
## Summary
Updated the alert component to properly merge extra attributes while disabling HTML escaping, allowing for more flexible attribute handling.

## Key Changes
- Modified the `<div>` element in `resources/views/components/alert.blade.php` to use `$attributes->merge($getExtraAttributes(), escape: false)` instead of just `$attributes`
- This ensures that extra attributes obtained from `$getExtraAttributes()` are merged into the element's attributes without escaping HTML content

## Implementation Details
- The `merge()` method is chained before the `class()` method to combine attributes from both `$attributes` and `$getExtraAttributes()`
- The `escape: false` parameter preserves any HTML entities or special characters in the extra attributes, which may be necessary for certain attribute values or configurations
- This change maintains backward compatibility while providing more control over attribute rendering in the alert component

https://claude.ai/code/session_01YXdi2QwojJReNnYFNKqKCk